### PR TITLE
Add test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Building
+
+1. First install `redo` and `scdoc` from the community repository
+2. Create the man pages with `redo build`
+
+# Testing
+
+1. First install `redo` and `bats` from the community repository
+1. Install `grep` from the main repository
+1. Make sure the directory containing `./apkbuild-lint` is on `$PATH`
+1. Run the tests with `redo check`

--- a/apkbuild-lint
+++ b/apkbuild-lint
@@ -137,8 +137,8 @@ superfluous_cd_builddir() {
 	# 3. grep for all ocurrences of the 'cd' command (ignore obviously invalid ones
 	#	like matching 'cd' until the end of the line)
 	cds="$(cat -n "$apkbuild" \
-		   | sed -n "/^   [0-9].*\t$phase() {/,/[0-9].*\t}/p" \
-		   | grep '\bcd ')" 
+		   | sed -n "/^\s\+[0-9].*\t$phase() {/,/[0-9].*\t}/p" \
+		   | grep '\bcd ')"
 
 	# Number of ocurrences of the 'cd' command being used
 	# Used to tell if we are in a phase() with a single cd statement
@@ -163,7 +163,7 @@ superfluous_cd_builddir() {
 		[ -z "$statement" ] && continue
 		if echo "$statement" | grep -q 'cd "$builddir"\($\| \)'; then
 			if [ "$prevcd" -eq 1 ] || [ "$cdscount" -eq 1 ]; then
-				printf "%s:%s: cd \"\$builddir\" can be removed in phase '%s'\\n" "$apkbuild" "$linenum" "$phase" 
+				printf "%s:%s: cd \"\$builddir\" can be removed in phase '%s'\\n" "$apkbuild" "$linenum" "$phase"
 			fi
 			prevcd=1
 		else

--- a/check.do
+++ b/check.do
@@ -1,0 +1,2 @@
+exec >&2
+bats --tap tests/apkbuild-lint.bats

--- a/tests/apkbuild-lint.bats
+++ b/tests/apkbuild-lint.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+cmd=./apkbuild-lint
+apkbuild=$BATS_TMPDIR/APKBUILD
+
+assert_match() {
+	output=$1
+	expected=$2
+
+	echo "$output" | grep -qE "$expected"
+}
+
+@test 'default builddir can be removed' {
+	cat <<-"EOF" >$apkbuild
+	pkgname=a
+	pkgver=1
+	builddir=/$pkgname-$pkgver
+
+	build() {
+		foo
+	}
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 1 ]]
+	assert_match "${lines[0]}" "builddir"
+}
+
+@test 'cd \"\$builddir\" is not highlighted' {
+	cat <<-"EOF" >$apkbuild
+	pkgname=a
+	subpackages="py-${pkgname}:_py"
+
+	_py() {
+		cd "$builddir" # required
+	}
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 0 ]]
+}
+
+@test 'cd \"\$builddir\" after cd should be ignored' {
+	cat <<-"EOF" >$apkbuild
+	pkgname=a
+	pkgver=1
+
+	build() {
+		cd "$builddir/bar"
+		foo
+		cd "$builddir"
+	}
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 0 ]]
+}
+
+@test 'unnecessary || return 1 can be removed' {
+	cat <<-"EOF" >$apkbuild
+	pkgname=a
+	pkgver=1
+
+	build() {
+		foo || return 1
+	}
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 1 ]]
+	assert_match "${lines[0]}" "return 1"
+}
+
+@test 'plain pkgname should not be quoted' {
+	cat <<-"EOF" >$apkbuild
+	pkgname="a"
+	pkgver=1
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 1 ]]
+	assert_match "${lines[0]}" "pkgname.*quoted"
+}
+
+@test 'quoted composed pkgname is fine' {
+	skip "false positive"
+	cat <<-"EOF" >$apkbuild
+	pkgname="a"
+	_flavor=foo
+	pkgname="$pkgname-$_flavor"
+	pkgver=1
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 0 ]]
+}
+
+@test 'pkgver should not be quoted' {
+	cat <<-"EOF" >$apkbuild
+	pkgname=a
+	pkgver="1"
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 1 ]]
+	assert_match "${lines[0]}" "pkgver.*quoted"
+}
+
+@test 'empty global variable can be removed' {
+	cat <<-"EOF" >$apkbuild
+	pkgname=a
+	pkgver=1
+	install=
+	EOF
+
+	run $cmd $apkbuild
+	[[ $status -eq 1 ]]
+	assert_match "${lines[0]}" "variable.*empty"
+}


### PR DESCRIPTION
Test 'empty global variable can be removed' is currently failing.

It also includes one compattibility fix for `superfluous_cd_builddir`.