### PR TITLE
Fix tests for underscore prefix

### DIFF
--- a/tests/apkbuild-lint.bats
+++ b/tests/apkbuild-lint.bats
@@ -126,7 +126,7 @@ is_travis() {
 	cat <<-"EOF" >$apkbuild
 	pkgname=a
 	pkgver=1
-	foo=
+	foo=example
 	EOF
 
 	run $cmd $apkbuild


### PR DESCRIPTION
Before this change apkbuild-lint finds an extra error in the test data:

    <file>:3: prefix custom variable with _: foo=
    <file>:3: variable set to empty string: foo=

After this change only the desired error is found:

    <file>:3: prefix custom variable with _: foo=example